### PR TITLE
BUGFIX: Initialize settings

### DIFF
--- a/Classes/Configuration/ConfigurationContainer.php
+++ b/Classes/Configuration/ConfigurationContainer.php
@@ -34,7 +34,7 @@ class ConfigurationContainer implements ConfigurationContainerInterface
      *
      * @var array
      */
-    protected $settings;
+    protected $settings = [];
 
     /**
      * Inject settings via ConfigurationManager.


### PR DESCRIPTION
* To allow ArrayUtility to work even if no settings were retrieved, e.g.
  in tests.