### PR TITLE
TASK: Upgrade phpunit to latest stable 5.7

### DIFF
--- a/Tests/Functional/Hooks/DataHandler/AbstractDataHandlerTest.php
+++ b/Tests/Functional/Hooks/DataHandler/AbstractDataHandlerTest.php
@@ -41,15 +41,10 @@ abstract class AbstractDataHandlerTest extends AbstractFunctionalTestCase
 
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
 
-        $this->subject = $this->getAccessibleMock(
-            DataHandlerService::class,
-            [
-                'add',
-                'update',
-                'delete',
-            ],
-            [$objectManager->get(ConfigurationContainerInterface::class)]
-        );
+        $this->subject = $this->getMockBuilder(DataHandlerService::class)
+            ->setConstructorArgs([$objectManager->get(ConfigurationContainerInterface::class)])
+            ->setMethods(['add', 'update', 'delete'])
+            ->getMock();
 
         // This way TYPO3 will use our mock instead of a new instance.
         $GLOBALS['T3_VAR']['getUserObj']['&' . DataHandlerHook::class] = new DataHandlerHook($this->subject);

--- a/Tests/Functional/Indexing/TcaIndexerTest.php
+++ b/Tests/Functional/Indexing/TcaIndexerTest.php
@@ -44,15 +44,11 @@ class TcaIndexerTest extends AbstractFunctionalTestCase
             $objectManager->get(RelationResolver::class),
             $objectManager->get(ConfigurationContainerInterface::class)
         );
-        $connection = $this->getAccessibleMock(
-            Elasticsearch::class,
-            [
-                'addDocuments',
-            ],
-            [],
-            '',
-            false
-        );
+
+        $connection = $this->getMockBuilder(Elasticsearch::class)
+            ->setMethods(['addDocuments'])
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $connection->expects($this->once())
             ->method('addDocuments')

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ruflin/elastica": "~3.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.0"
+        "phpunit/phpunit": "~5.7.0"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
* To make use of new features.
* To reduce cost of later migrations.
* Migrate deprecated calls from lower TYPO3 api.