### PR TITLE
BUGFIX: Allow tests to run on travis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
       - oracle-java8-set-default
 before_install:
   - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.2.0.deb && sudo dpkg -i --force-confnew elasticsearch-5.2.0.deb && sudo service elasticsearch start
+  - mysql -u root -e 'GRANT ALL ON `typo3_ci_ft%`.* TO travis@127.0.0.1;'
 
 language: php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,23 +24,7 @@ env:
     - typo3DatabaseHost="127.0.0.1"
     - typo3DatabaseUsername="travis"
     - typo3DatabasePassword=""
-  matrix:
     - TYPO3_VERSION="~7.6"
-    - TYPO3_VERSION="~8"
-    - TYPO3_VERSION="dev-master"
-
-matrix:
-  fast_finish: true
-  exclude:
-  allow_failures:
-    - env: TYPO3_VERSION="~8"
-      php: 7.0
-    - env: TYPO3_VERSION="~8"
-      php: 7.1
-    - env: TYPO3_VERSION="dev-master"
-      php: 7.0
-    - env: TYPO3_VERSION="dev-master"
-      php: 7.1
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_install:
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
 
@@ -33,11 +32,6 @@ env:
 matrix:
   fast_finish: true
   exclude:
-    # TYPO3 no longer supports 5.6
-    - env: TYPO3_VERSION="~8"
-      php: 5.6
-    - env: TYPO3_VERSION="dev-master"
-      php: 5.6
   allow_failures:
     - env: TYPO3_VERSION="~8"
       php: 7.0


### PR DESCRIPTION
In order to run functional tests, we need to grand necessary permissions
on travis.
Also run only working and supported TYPO3 and PHP combinations.