### PR TITLE
FEATURE: Respect inherited start- and endtime for pages

### DIFF
--- a/Classes/Domain/Index/TcaIndexer/TcaTableService.php
+++ b/Classes/Domain/Index/TcaIndexer/TcaTableService.php
@@ -275,7 +275,9 @@ class TcaTableService
 
         foreach ($rootline as $pageInRootLine) {
             // Check configured black list if present.
-            if ($this->isBlackListedRootLineConfigured() && in_array($pageInRootLine['uid'], $this->getBlackListedRootLine())) {
+            if ($this->isBlackListedRootLineConfigured()
+                && in_array($pageInRootLine['uid'], $this->getBlackListedRootLine())
+            ) {
                 return true;
             }
             if ($pageInRootLine['extendToSubpages'] && (

--- a/Tests/Functional/Fixtures/Indexing/PagesIndexer/BrokenRootLine.xml
+++ b/Tests/Functional/Fixtures/Indexing/PagesIndexer/BrokenRootLine.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <!-- DISABLED PAGES -->
+    <pages>
+        <uid>3</uid>
+        <pid>2</pid>
+        <title>Some disabled page due broken root line</title>
+    </pages>
+    <pages>
+        <uid>4</uid>
+        <pid>3</pid>
+        <title>Some disabled page due to parent pages root line being broken</title>
+    </pages>
+    <!-- ENABLED PAGES -->
+    <pages>
+        <uid>6</uid>
+        <pid>1</pid>
+        <title>Some enabled page due valid root line</title>
+    </pages>
+</dataset>

--- a/Tests/Functional/Fixtures/Indexing/PagesIndexer/InheritedTiming.xml
+++ b/Tests/Functional/Fixtures/Indexing/PagesIndexer/InheritedTiming.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <!-- DISABLED PAGES -->
+    <pages>
+        <uid>2</uid>
+        <pid>1</pid>
+        <title>Some disabled page due to timing</title>
+        <endtime>1502186635</endtime>
+        <extendToSubpages>1</extendToSubpages>
+    </pages>
+    <pages>
+        <uid>3</uid>
+        <pid>2</pid>
+        <title>Some disabled page due to inherited timing</title>
+    </pages>
+    <pages>
+        <uid>4</uid>
+        <pid>1</pid>
+        <title>Some disabled page due to timing</title>
+        <starttime>2147483647</starttime>
+        <extendToSubpages>1</extendToSubpages>
+    </pages>
+    <pages>
+        <uid>5</uid>
+        <pid>4</pid>
+        <title>Some disabled page due to inherited timing</title>
+    </pages>
+    <!-- ENABLED PAGES -->
+    <pages>
+        <uid>6</uid>
+        <pid>1</pid>
+        <title>Some enabled page due to no be below inherited disabled timing</title>
+    </pages>
+</dataset>

--- a/Tests/Functional/Fixtures/Indexing/PagesIndexer/Recycler.xml
+++ b/Tests/Functional/Fixtures/Indexing/PagesIndexer/Recycler.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <!-- DISABLED PAGES -->
+    <pages>
+        <uid>2</uid>
+        <pid>1</pid>
+        <title>Some disabled page due being recycler</title>
+        <doktype>255</doktype>
+    </pages>
+    <pages>
+        <uid>3</uid>
+        <pid>2</pid>
+        <title>Some disabled page due to parent page being recycler</title>
+    </pages>
+    <!-- ENABLED PAGES -->
+    <pages>
+        <uid>6</uid>
+        <pid>1</pid>
+        <title>Some enabled page due to no be below recycler</title>
+    </pages>
+</dataset>

--- a/Tests/Functional/Indexing/PagesIndexerTest.php
+++ b/Tests/Functional/Indexing/PagesIndexerTest.php
@@ -61,4 +61,33 @@ class PagesIndexerTest extends AbstractFunctionalTestCase
         $this->inject($indexer, 'connection', $connection);
         $indexer->indexAllDocuments();
     }
+
+    /**
+     * @test
+     */
+    public function inheritedTimingIsRespectedDuringIndexing()
+    {
+        $this->importDataSet('Tests/Functional/Fixtures/Indexing/PagesIndexer/InheritedTiming.xml');
+
+        $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class);
+        $tableName = 'pages';
+
+        $connection = $this->getMockBuilder(Elasticsearch::class)
+            ->setMethods(['addDocuments'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $connection->expects($this->once())
+            ->method('addDocuments')
+            ->with(
+                $this->stringContains($tableName),
+                $this->callback(function ($documents) {
+                    return count($documents) === 2;
+                })
+            );
+
+        $indexer = $objectManager->get(IndexerFactory::class)->getIndexer($tableName);
+        $this->inject($indexer, 'connection', $connection);
+        $indexer->indexAllDocuments();
+    }
 }

--- a/Tests/Functional/Indexing/PagesIndexerTest.php
+++ b/Tests/Functional/Indexing/PagesIndexerTest.php
@@ -64,10 +64,12 @@ class PagesIndexerTest extends AbstractFunctionalTestCase
 
     /**
      * @test
+     * @dataProvider rootLineDataSets
+     * @param string $dataSetPath
      */
-    public function inheritedTimingIsRespectedDuringIndexing()
+    public function rootLineIsRespectedDuringIndexing($dataSetPath)
     {
-        $this->importDataSet('Tests/Functional/Fixtures/Indexing/PagesIndexer/InheritedTiming.xml');
+        $this->importDataSet($dataSetPath);
 
         $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class);
         $tableName = 'pages';
@@ -89,5 +91,14 @@ class PagesIndexerTest extends AbstractFunctionalTestCase
         $indexer = $objectManager->get(IndexerFactory::class)->getIndexer($tableName);
         $this->inject($indexer, 'connection', $connection);
         $indexer->indexAllDocuments();
+    }
+
+    public function rootLineDataSets()
+    {
+        return [
+            'Broken root line' => ['Tests/Functional/Fixtures/Indexing/PagesIndexer/BrokenRootLine.xml'],
+            'Recycler doktype' => ['Tests/Functional/Fixtures/Indexing/PagesIndexer/Recycler.xml'],
+            'Extended timing to sub pages' => ['Tests/Functional/Fixtures/Indexing/PagesIndexer/InheritedTiming.xml'],
+        ];
     }
 }


### PR DESCRIPTION
Do not index records below tables that extend their start- or endtime to
their subpages are not accessible due to timing now.