### PR TITLE
TASK: Allow integrators to use GET with minimal overhead

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -56,6 +56,12 @@ class SearchController extends ActionController
                 ]
             ));
         }
+
+        if ($this->arguments->hasArgument('searchRequest')) {
+            $this->arguments->getArgument('searchRequest')->getPropertyMappingConfiguration()
+                ->allowAllProperties()
+                ;
+        }
     }
 
     /**

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -31,9 +31,6 @@ call_user_func(
             'search',
             [
                 'Search' => 'search'
-            ],
-            [
-                'Search' => 'search' // TODO: Enable caching. But submitting form results in previous result?!
             ]
         );
 


### PR DESCRIPTION
Allow to map search request even if no trusted properties exist.
Also cache initial call to plugin.

This allows to use GET as submit for forms with minimal arguments in
URL.