### PR TITLE
BUGFIX: Do not remove submitted filter if configured one is empty

### DIFF
--- a/Classes/Domain/Search/SearchService.php
+++ b/Classes/Domain/Search/SearchService.php
@@ -26,6 +26,7 @@ use Codappix\SearchCore\Connection\ConnectionInterface;
 use Codappix\SearchCore\Connection\SearchRequestInterface;
 use Codappix\SearchCore\Connection\SearchResultInterface;
 use Codappix\SearchCore\Domain\Model\FacetRequest;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
 /**
@@ -123,10 +124,16 @@ class SearchService
     protected function addConfiguredFilters(SearchRequestInterface $searchRequest)
     {
         try {
-            $searchRequest->setFilter(array_merge(
-                $searchRequest->getFilter(),
-                $this->configuration->get('searching.filter')
-            ));
+            $filter = $searchRequest->getFilter();
+
+            ArrayUtility::mergeRecursiveWithOverrule(
+                $filter,
+                $this->configuration->get('searching.filter'),
+                true,
+                false
+            );
+
+            $searchRequest->setFilter($filter);
         } catch (InvalidArgumentException $e) {
             // Nothing todo, no filter configured.
         }

--- a/Tests/Unit/Domain/Search/SearchServiceTest.php
+++ b/Tests/Unit/Domain/Search/SearchServiceTest.php
@@ -178,4 +178,29 @@ class SearchServiceTest extends AbstractUnitTestCase
         $searchRequest->setFilter(['anotherProperty' => 'anything']);
         $this->subject->search($searchRequest);
     }
+
+    /**
+     * @test
+     */
+    public function emptyConfiguredFilterIsNotChangingRequestWithExistingFilter()
+    {
+        $this->configuration->expects($this->exactly(2))
+            ->method('getIfExists')
+            ->withConsecutive(['searching.size'], ['searching.facets'])
+            ->will($this->onConsecutiveCalls(null, null));
+        $this->configuration->expects($this->exactly(1))
+            ->method('get')
+            ->with('searching.filter')
+            ->willReturn(['anotherProperty' => '']);
+
+        $this->connection->expects($this->once())
+            ->method('search')
+            ->with($this->callback(function ($searchRequest) {
+                return $searchRequest->getFilter() === ['anotherProperty' => 'anything'];
+            }));
+
+        $searchRequest = new SearchRequest('SearchWord');
+        $searchRequest->setFilter(['anotherProperty' => 'anything']);
+        $this->subject->search($searchRequest);
+    }
 }


### PR DESCRIPTION
This will be the case if you add a flexform to the plugin with no value.
Then an empty filter is configured and you will not be able to submit a
value for this filter.