### PR TITLE
FEATURE: Add data processor to remove fields for indexing

### DIFF
--- a/Classes/DataProcessing/RemoveProcessor.php
+++ b/Classes/DataProcessing/RemoveProcessor.php
@@ -34,7 +34,7 @@ class RemoveProcessor implements ProcessorInterface
         }
 
         foreach (GeneralUtility::trimExplode(',', $configuration['fields'], true) as $field) {
-            if (isset($record[$field])) {
+            if (array_key_exists($field, $record)) {
                 unset($record[$field]);
             }
         }

--- a/Classes/DataProcessing/RemoveProcessor.php
+++ b/Classes/DataProcessing/RemoveProcessor.php
@@ -1,0 +1,44 @@
+<?php
+namespace Codappix\SearchCore\DataProcessing;
+
+/*
+ * Copyright (C) 2017  Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Removes fields from record.
+ */
+class RemoveProcessor implements ProcessorInterface
+{
+    public function processRecord(array $record, array $configuration) : array
+    {
+        if (!isset($configuration['fields'])) {
+            return $record;
+        }
+
+        foreach (GeneralUtility::trimExplode(',', $configuration['fields'], true) as $field) {
+            if (isset($record[$field])) {
+                unset($record[$field]);
+            }
+        }
+
+        return $record;
+    }
+}

--- a/Documentation/source/configuration/dataProcessing/RemoveProcessor.rst
+++ b/Documentation/source/configuration/dataProcessing/RemoveProcessor.rst
@@ -15,7 +15,7 @@ Example::
         1 {
             fields = description
         }
-        2 = Codappix\SearchCore\DataProcessing\CopyToProcessor
+        2 = Codappix\SearchCore\DataProcessing\RemoveProcessor
         2 {
             fields = description, another_field
         }

--- a/Documentation/source/configuration/dataProcessing/RemoveProcessor.rst
+++ b/Documentation/source/configuration/dataProcessing/RemoveProcessor.rst
@@ -1,0 +1,23 @@
+``Codappix\SearchCore\DataProcessing\RemoveProcessor``
+======================================================
+
+Will remove fields from record, e.g. if you do not want to sent them to elasticsearch at all.
+
+Possible Options:
+
+``fields``
+    Comma separated list of fields to remove from record.
+
+Example::
+
+    plugin.tx_searchcore.settings.indexing.tt_content.dataProcessing {
+        1 = Codappix\SearchCore\DataProcessing\RemoveProcessor
+        1 {
+            fields = description
+        }
+        2 = Codappix\SearchCore\DataProcessing\CopyToProcessor
+        2 {
+            fields = description, another_field
+        }
+    }
+

--- a/Documentation/source/configuration/indexing.rst
+++ b/Documentation/source/configuration/indexing.rst
@@ -180,6 +180,7 @@ The following Processor are available:
     :glob:
 
     dataProcessing/CopyToProcessor
+    dataProcessing/RemoveProcessor
     dataProcessing/GeoPointProcessor
 
 The following Processor are planned:

--- a/Tests/Unit/DataProcessing/RemoveProcessorTest.php
+++ b/Tests/Unit/DataProcessing/RemoveProcessorTest.php
@@ -1,0 +1,122 @@
+<?php
+namespace Codappix\SearchCore\Tests\Unit\DataProcessing;
+
+/*
+ * Copyright (C) 2017  Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use Codappix\SearchCore\DataProcessing\RemoveProcessor;
+use Codappix\SearchCore\Tests\Unit\AbstractUnitTestCase;
+
+class RemoveProcessorTest extends AbstractUnitTestCase
+{
+    /**
+     * @test
+     * @dataProvider getPossibleRecordConfigurationCombinations
+     */
+    public function fieldsAreCopiedAsConfigured(array $record, array $configuration, array $expectedRecord)
+    {
+        $subject = new RemoveProcessor();
+        $processedRecord = $subject->processRecord($record, $configuration);
+        $this->assertSame(
+            $expectedRecord,
+            $processedRecord,
+            'The processor did not return the expected processed record.'
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function getPossibleRecordConfigurationCombinations()
+    {
+        return [
+            'Nothing configured' => [
+                'record' => [
+                    'field 1' => 'Some content like lorem',
+                    'field with sub2' => [
+                        'Tag 1',
+                        'Tag 2',
+                    ],
+                ],
+                'configuration' => [
+                ],
+                'expectedRecord' => [
+                    'field 1' => 'Some content like lorem',
+                    'field with sub2' => [
+                        'Tag 1',
+                        'Tag 2',
+                    ],
+                ],
+            ],
+            'Single field configured' => [
+                'record' => [
+                    'field 1' => 'Some content like lorem',
+                    'field with sub2' => [
+                        'Tag 1',
+                        'Tag 2',
+                    ],
+                ],
+                'configuration' => [
+                    'fields' => 'field with sub2',
+                    '_typoScriptNodeValue' => 'Codappix\SearchCore\DataProcessing\RemoveProcessor',
+                ],
+                'expectedRecord' => [
+                    'field 1' => 'Some content like lorem',
+                ],
+            ],
+            'Non existing field configured' => [
+                'record' => [
+                    'field 1' => 'Some content like lorem',
+                    'field with sub2' => [
+                        'Tag 1',
+                        'Tag 2',
+                    ],
+                ],
+                'configuration' => [
+                    'fields' => 'non existing',
+                    '_typoScriptNodeValue' => 'Codappix\SearchCore\DataProcessing\RemoveProcessor',
+                ],
+                'expectedRecord' => [
+                    'field 1' => 'Some content like lorem',
+                    'field with sub2' => [
+                        'Tag 1',
+                        'Tag 2',
+                    ],
+                ],
+            ],
+            'Multiple fields configured' => [
+                'record' => [
+                    'field 1' => 'Some content like lorem',
+                    'field with sub2' => [
+                        'Tag 1',
+                        'Tag 2',
+                    ],
+                    'field 3' => 'Some more like lorem',
+                ],
+                'configuration' => [
+                    'fields' => 'field 3, field with sub2',
+                    '_typoScriptNodeValue' => 'Codappix\SearchCore\DataProcessing\RemoveProcessor',
+                ],
+                'expectedRecord' => [
+                    'field 1' => 'Some content like lorem',
+                ],
+            ],
+        ];
+    }
+}

--- a/Tests/Unit/DataProcessing/RemoveProcessorTest.php
+++ b/Tests/Unit/DataProcessing/RemoveProcessorTest.php
@@ -117,6 +117,17 @@ class RemoveProcessorTest extends AbstractUnitTestCase
                     'field 1' => 'Some content like lorem',
                 ],
             ],
+            'Fields with "null" san be removed' => [
+                'record' => [
+                    'field 1' => null,
+                ],
+                'configuration' => [
+                    'fields' => 'field 1',
+                    '_typoScriptNodeValue' => 'Codappix\SearchCore\DataProcessing\RemoveProcessor',
+                ],
+                'expectedRecord' => [
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Add a new processor, with docs and tests, to allow removal of fields
before sending them to search service like elasticsearch.

E.g. remove sensitive information that should not be available.