### PR TITLE
BUGFIX: Remove records during update if no longer available

### DIFF
--- a/Classes/Domain/Index/AbstractIndexer.php
+++ b/Classes/Domain/Index/AbstractIndexer.php
@@ -99,7 +99,8 @@ abstract class AbstractIndexer implements IndexerInterface
 
             $this->connection->addDocument($this->getDocumentName(), $record);
         } catch (NoRecordFoundException $e) {
-            $this->logger->info('Could not index document.', [$e->getMessage()]);
+            $this->logger->info('Could not index document. Try to delete it therefore.', [$e->getMessage()]);
+            $this->connection->deleteDocument($this->getDocumentName(), $identifier);
         }
         $this->logger->info('Finish indexing');
     }

--- a/Tests/Functional/Connection/Elasticsearch/IndexTcaTableTest.php
+++ b/Tests/Functional/Connection/Elasticsearch/IndexTcaTableTest.php
@@ -205,4 +205,35 @@ class IndexTcaTableTest extends AbstractFunctionalTestCase
             'Record was indexed with resolved category relation, but should not have any.'
         );
     }
+
+    /**
+     * @test
+     */
+    public function indexingDeltedRecordIfRecordShouldBeIndexedButIsNoLongerAvailableAndWasAlreadyIndexed()
+    {
+        \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class)
+            ->get(IndexerFactory::class)
+            ->getIndexer('tt_content')
+            ->indexAllDocuments()
+            ;
+
+        $response = $this->client->request('typo3content/_search?q=*:*');
+        $this->assertSame($response->getData()['hits']['total'], 2, 'Not exactly 2 documents were indexed.');
+
+        $this->getConnectionPool()->getConnectionForTable('tt_content')
+            ->update(
+                'tt_content',
+                ['hidden' => true],
+                ['uid' => 10]
+            );
+
+        \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class)
+            ->get(IndexerFactory::class)
+            ->getIndexer('tt_content')
+            ->indexDocument(10)
+            ;
+
+        $response = $this->client->request('typo3content/_search?q=*:*');
+        $this->assertSame($response->getData()['hits']['total'], 1, 'Not exactly 1 document is in index.');
+    }
 }


### PR DESCRIPTION
E.g. update is to deactivate a record. In this case we will not be able
to update the record but should delete him instead.