### PR TITLE
BUGFIX: Reset array_keys for pages field media

### DIFF
--- a/Classes/Domain/Index/TcaIndexer/PagesIndexer.php
+++ b/Classes/Domain/Index/TcaIndexer/PagesIndexer.php
@@ -74,7 +74,7 @@ class PagesIndexer extends TcaIndexer
         $content = $this->fetchContentForPage($record['uid']);
         if ($content !== []) {
             $record['content'] = $content['content'];
-            $record['media'] = array_unique(array_merge($record['media'], $content['images']));
+            $record['media'] = array_values(array_unique(array_merge($record['media'], $content['images'])));
         }
         parent::prepareRecord($record);
     }


### PR DESCRIPTION
Due to filtering some keys might be missing, so we will have:
```
0 => '',
2 => '',
```

This will lead to elasticsearch exceptions during bulk processing.
Therefore we reset keys to prevent this issue.