### PR TITLE
BUGFIX: Check if lat/lng isset and set filter to empty string

### DIFF
--- a/Classes/Domain/Search/QueryFactory.php
+++ b/Classes/Domain/Search/QueryFactory.php
@@ -229,6 +229,10 @@ class QueryFactory
 
         if (isset($config['fields'])) {
             foreach ($config['fields'] as $elasticField => $inputField) {
+                if (! isset($value[$inputField])) {
+                    $value[$inputField] = '';
+                }
+
                 $filter[$elasticField] = $value[$inputField];
             }
         }


### PR DESCRIPTION
If the lat/lng is empty the search has an exception.
This way the search is empty and no results could be found.