### PR TITLE
Hotfix: Index media field for pages

### DIFF
--- a/Classes/Domain/Index/TcaIndexer/PagesIndexer.php
+++ b/Classes/Domain/Index/TcaIndexer/PagesIndexer.php
@@ -124,18 +124,7 @@ class PagesIndexer extends TcaIndexer
      */
     protected function getContentElementImages($uidOfContentElement)
     {
-        $imageRelationUids = [];
-        $imageRelations = $this->fileRepository->findByRelation(
-            'tt_content',
-            'image',
-            $uidOfContentElement
-        );
-
-        foreach ($imageRelations as $relation) {
-            $imageRelationUids[] = $relation->getUid();
-        }
-
-        return $imageRelationUids;
+        return $this->fetchSysFileReferenceUids($uidOfContentElement, 'tt_content', 'image');
     }
 
     /**
@@ -144,12 +133,19 @@ class PagesIndexer extends TcaIndexer
      */
     protected function fetchMediaForPage($uid)
     {
+        return $this->fetchSysFileReferenceUids($uid, 'pages', 'media');
+    }
+
+    /**
+     * @param int $uid
+     * @param string $tablename
+     * @param string $fieldname
+     * @return []
+     */
+    protected function fetchSysFileReferenceUids($uid, $tablename, $fieldname)
+    {
         $imageRelationUids = [];
-        $imageRelations = $this->fileRepository->findByRelation(
-            'pages',
-            'media',
-            $uid
-        );
+        $imageRelations = $this->fileRepository->findByRelation($tablename, $fieldname, $uid);
 
         foreach ($imageRelations as $relation) {
             $imageRelationUids[] = $relation->getUid();

--- a/Classes/Domain/Index/TcaIndexer/PagesIndexer.php
+++ b/Classes/Domain/Index/TcaIndexer/PagesIndexer.php
@@ -71,6 +71,7 @@ class PagesIndexer extends TcaIndexer
             }
         }
 
+        $record['media'] = $this->fetchMediaForPage($record['uid']);
         $content = $this->fetchContentForPage($record['uid']);
         if ($content !== []) {
             $record['content'] = $content['content'];
@@ -128,6 +129,26 @@ class PagesIndexer extends TcaIndexer
             'tt_content',
             'image',
             $uidOfContentElement
+        );
+
+        foreach ($imageRelations as $relation) {
+            $imageRelationUids[] = $relation->getUid();
+        }
+
+        return $imageRelationUids;
+    }
+
+    /**
+     * @param int $uid
+     * @return []
+     */
+    protected function fetchMediaForPage($uid)
+    {
+        $imageRelationUids = [];
+        $imageRelations = $this->fileRepository->findByRelation(
+            'pages',
+            'media',
+            $uid
         );
 
         foreach ($imageRelations as $relation) {

--- a/Tests/Functional/Connection/Elasticsearch/IndexTcaTableTest.php
+++ b/Tests/Functional/Connection/Elasticsearch/IndexTcaTableTest.php
@@ -205,4 +205,33 @@ class IndexTcaTableTest extends AbstractFunctionalTestCase
             'Record was indexed with resolved category relation, but should not have any.'
         );
     }
+
+    /**
+     * @test
+     */
+    public function indexPagesMedia()
+    {
+        \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class)
+            ->get(IndexerFactory::class)
+            ->getIndexer('pages')
+            ->indexAllDocuments()
+            ;
+
+        $response = $this->client->request('typo3content/_search?q=*:*');
+
+        $this->assertTrue($response->isOK(), 'Elastica did not answer with ok code.');
+        $this->assertSame($response->getData()['hits']['total'], 2, 'Not exactly 2 documents were indexed.');
+        $this->assertArraySubset(
+            [
+                '_source' => [
+                    'media' => [
+                        10, 1
+                    ]
+                ]
+            ],
+            $response->getData()['hits']['hits'][0],
+            false,
+            'Record was not indexed.'
+        );
+    }
 }

--- a/Tests/Functional/Fixtures/Indexing/IndexTcaTable.xml
+++ b/Tests/Functional/Fixtures/Indexing/IndexTcaTable.xml
@@ -99,4 +99,71 @@
         <colPos>0</colPos>
         <filelink_sorting>0</filelink_sorting>
     </tt_content>
+
+    <pages>
+        <uid>2</uid>
+        <pid>1</pid>
+        <title>Example page with </title>
+        <description>Used as abstract as no abstract is defined.</description>
+        <media>2</media>
+    </pages>
+
+    <sys_file_reference>
+        <uid>1</uid>
+        <pid>1</pid>
+        <uid_local>1</uid_local>
+        <uid_foreign>2</uid_foreign>
+        <tablenames>pages</tablenames>
+        <fieldname>media</fieldname>
+        <sorting_foreign>2</sorting_foreign>
+        <table_local>sys_file</table_local>
+
+        <l10n_diffsource></l10n_diffsource>
+    </sys_file_reference>
+
+    <sys_file_reference>
+        <uid>10</uid>
+        <pid>1</pid>
+        <uid_local>2</uid_local>
+        <uid_foreign>2</uid_foreign>
+        <tablenames>pages</tablenames>
+        <fieldname>media</fieldname>
+        <sorting_foreign>1</sorting_foreign>
+        <table_local>sys_file</table_local>
+
+        <l10n_diffsource></l10n_diffsource>
+    </sys_file_reference>
+
+    <sys_file>
+        <uid>1</uid>
+        <pid>0</pid>
+        <storage>1</storage>
+        <type>2</type>
+        <identifier>full/file/path.png</identifier>
+        <identifier_hash>94dd1f9645114cf1344438ac7188db972768f59f</identifier_hash>
+        <folder_hash>67887283a03f465f1004d1d43a157ee1f1c59be5</folder_hash>
+        <extension>png</extension>
+        <mime_type>image/png</mime_type>
+        <name>path2.png</name>
+        <sha1>c1dd34eb34d651ee6ca6ac52dea595db75d8e9d2</sha1>
+        <size>3044</size>
+        <creation_date>1432306303</creation_date>
+        <modification_date>1432306303</modification_date>
+    </sys_file>
+    <sys_file>
+        <uid>2</uid>
+        <pid>0</pid>
+        <storage>1</storage>
+        <type>2</type>
+        <identifier>full/file/path2.png</identifier>
+        <identifier_hash>94dd1f9645114cf1344438ac7188db972768f59f</identifier_hash>
+        <folder_hash>67887283a03f465f1004d1d43a157ee1f1c59be5</folder_hash>
+        <extension>png</extension>
+        <mime_type>image/png</mime_type>
+        <name>path2.png</name>
+        <sha1>c1dd34eb34d651ee6ca6ac52dea595db75d8e9d2</sha1>
+        <size>3044</size>
+        <creation_date>1432306303</creation_date>
+        <modification_date>1432306303</modification_date>
+    </sys_file>
 </dataset>

--- a/Tests/Functional/Indexing/PagesIndexerTest.php
+++ b/Tests/Functional/Indexing/PagesIndexerTest.php
@@ -48,7 +48,7 @@ class PagesIndexerTest extends AbstractFunctionalTestCase
             ->with(
                 $this->stringContains($tableName),
                 $this->callback(function ($documents) {
-                    return count($documents) === 1
+                    return count($documents) === 2
                         && isset($documents[0]['content']) && $documents[0]['content'] ===
                         'this is the content of header content element that should get indexed Some text in paragraph'
                         && isset($documents[0]['search_abstract']) && $documents[0]['search_abstract'] ===

--- a/Tests/Functional/Indexing/PagesIndexerTest.php
+++ b/Tests/Functional/Indexing/PagesIndexerTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Codappix\SearchCore\Tests\Indexing;
+namespace Codappix\SearchCore\Tests\Functional\Indexing;
 
 /*
  * Copyright (C) 2016  Daniel Siepmann <coding@daniel-siepmann.de>

--- a/Tests/Functional/Indexing/TcaIndexer/RelationResolverTest.php
+++ b/Tests/Functional/Indexing/TcaIndexer/RelationResolverTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Codappix\SearchCore\Tests\Indexing\TcaIndexer;
+namespace Codappix\SearchCore\Tests\Indexing\Functional\TcaIndexer;
 
 /*
  * Copyright (C) 2016  Daniel Siepmann <coding@daniel-siepmann.de>

--- a/Tests/Functional/Indexing/TcaIndexerTest.php
+++ b/Tests/Functional/Indexing/TcaIndexerTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Codappix\SearchCore\Tests\Indexing;
+namespace Codappix\SearchCore\Tests\Functional\Indexing;
 
 /*
  * Copyright (C) 2016  Daniel Siepmann <coding@daniel-siepmann.de>


### PR DESCRIPTION
Always index media field of pages as array.
Index reference_uids for files.