### PR TITLE
FEATURE: Allow to disable elasticsearch integration

### DIFF
--- a/Documentation/source/configuration.rst
+++ b/Documentation/source/configuration.rst
@@ -5,9 +5,12 @@
 Configuration
 =============
 
+Installation wide configuration is handled inside of the extension manager. Just check out the
+options there, they all have labels.
+
 The extension offers the following configuration options through TypoScript. If you overwrite them
 through `setup` make sure to keep them in the `module` area as they will be accessed from backend
-mode of TYPO3. Do so by placing the following line at the end::
+mode of TYPO3 for indexing. Do so by placing the following line at the end::
 
     module.tx_searchcore < plugin.tx_searchcore
 

--- a/Documentation/source/installation.rst
+++ b/Documentation/source/installation.rst
@@ -19,4 +19,8 @@ In that case you need to install all dependencies yourself. Dependencies are:
 Afterwards you need to enable the extension through the extension manager and include the static
 TypoScript setup.
 
+If you **don't** want to use the included elasticsearch integration, you have to disable it in the
+extension manager configuration of the extension by checking the checkbox.
+It's currently enabled by default but will be moved into its own extension in the future.
+
 .. _downloading: https://github.com/DanielSiepmann/search_core/archive/master.zip

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,4 @@
+disable {
+    # cat=basic/enable; type=boolean; label=Disable Elasticsearch, which is enabled by default
+    elasticsearch = true
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -37,11 +37,18 @@ call_user_func(
             ]
         );
 
-        \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\Container\Container')
-            ->registerImplementation(
-                'Codappix\SearchCore\Connection\ConnectionInterface',
-                'Codappix\SearchCore\Connection\Elasticsearch'
-            );
+        // API does make use of object manager, therefore use GLOBALS
+        $extensionConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$extensionKey]);
+        if ($extensionConfiguration === false
+            || !isset($extensionConfiguration['disable.']['elasticsearch'])
+            || $extensionConfiguration['disable.']['elasticsearch'] !== '1'
+        ) {
+            \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\Object\Container\Container::class)
+                ->registerImplementation(
+                    \Codappix\SearchCore\Connection\ConnectionInterface::class,
+                    \Codappix\SearchCore\Connection\Elasticsearch::class
+                );
+        }
     },
     $_EXTKEY
 );


### PR DESCRIPTION
This extension currently ships with Elasticsearch integration which is
enabled by default. This behaviour is kept for backwards compatibility.
Still you now have the possibility to disable this integration in
extension manager, just check the "disable" box for elasticsearch.

In the future elasticsearch will become another extension and no default
is shipped with search_core. But for now, as we are still in alpha /
beta phase we keep things together to keep development fast.

Resolves: #111