### PR TITLE
TASK: Support PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 language: php
 
 php:
+  - 7.0
   - 7.1
 
 env:

--- a/Classes/Domain/Index/TcaIndexer/RelationResolver.php
+++ b/Classes/Domain/Index/TcaIndexer/RelationResolver.php
@@ -33,7 +33,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class RelationResolver implements Singleton
 {
-    public function resolveRelationsForRecord(TcaTableService $service, array &$record) : void
+    public function resolveRelationsForRecord(TcaTableService $service, array &$record)
     {
         foreach (array_keys($record) as $column) {
             // TODO: Define / configure fields to exclude?!

--- a/Classes/Domain/Index/TcaIndexer/TcaTableService.php
+++ b/Classes/Domain/Index/TcaIndexer/TcaTableService.php
@@ -129,7 +129,7 @@ class TcaTableService
      * @param array &$records
      * @return void
      */
-    public function filterRecordsByRootLineBlacklist(array &$records) : void
+    public function filterRecordsByRootLineBlacklist(array &$records)
     {
         $records = array_filter(
             $records,
@@ -142,7 +142,7 @@ class TcaTableService
     /**
      * @param array &$record
      */
-    public function prepareRecord(array &$record) : void
+    public function prepareRecord(array &$record)
     {
         $this->relationResolver->resolveRelationsForRecord($this, $record);
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ typo3DatabaseHost ?= "127.0.0.1"
 
 .PHONY: install
 install: clean
-	COMPOSER_PROCESS_TIMEOUT=1000 composer require -vv --dev --prefer-dist --ignore-platform-reqs typo3/cms="$(TYPO3_VERSION)"
+	COMPOSER_PROCESS_TIMEOUT=1000 composer require -vv --dev --prefer-dist typo3/cms="$(TYPO3_VERSION)"
 	git checkout composer.json
 
 functionalTests:

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
             "TYPO3\\CMS\\Core\\Tests\\": ".Build/vendor/typo3/cms/typo3/sysext/core/Tests/"
         }
     },
-    "require" : {
-        "php": ">=7.1.0",
+    "require": {
+        "php": ">=7.0.0",
         "typo3/cms": "~8.7",
         "ruflin/elastica": "~3.2"
     },


### PR DESCRIPTION
As some (e.g. debian) do not provide PHP 7.1 and we did not use so much
features which were introduced in PHP 7.1, we add support for PHP 7.0.