### PR TITLE
FEATURE: Use extbase for processor instantiation

### DIFF
--- a/Classes/Domain/Index/AbstractIndexer.php
+++ b/Classes/Domain/Index/AbstractIndexer.php
@@ -49,6 +49,12 @@ abstract class AbstractIndexer implements IndexerInterface
     protected $logger;
 
     /**
+     * @var \TYPO3\CMS\Extbase\Object\ObjectManagerInterface
+     * @inject
+     */
+    protected $objectManager;
+
+    /**
      * Inject log manager to get concrete logger from it.
      *
      * @param \TYPO3\CMS\Core\Log\LogManager $logManager
@@ -141,7 +147,8 @@ abstract class AbstractIndexer implements IndexerInterface
                 } else {
                     $className = $configuration['_typoScriptNodeValue'];
                 }
-                $dataProcessor = GeneralUtility::makeInstance($className);
+
+                $dataProcessor = $this->objectManager->get($className);
                 if ($dataProcessor instanceof ProcessorInterface) {
                     $record = $dataProcessor->processRecord($record, $configuration);
                 }

--- a/Documentation/source/configuration/indexing.rst
+++ b/Documentation/source/configuration/indexing.rst
@@ -205,3 +205,6 @@ class name) as done in the examples above.
 By implementing also the same interface as necessary for TYPO3
 :ref:`t3tsref:cobj-fluidtemplate-properties-dataprocessing`, you are able to reuse the same code
 also for Fluid to prepare the same record fetched from DB for your fluid.
+
+Dependency injection is possible inside of processors, as we instantiate through extbase
+``ObjectManager``.

--- a/Tests/Unit/Domain/Index/AbstractIndexerTest.php
+++ b/Tests/Unit/Domain/Index/AbstractIndexerTest.php
@@ -26,6 +26,7 @@ use Codappix\SearchCore\Connection\ConnectionInterface;
 use Codappix\SearchCore\DataProcessing\CopyToProcessor;
 use Codappix\SearchCore\Domain\Index\AbstractIndexer;
 use Codappix\SearchCore\Tests\Unit\AbstractUnitTestCase;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
 class AbstractIndexerTest extends AbstractUnitTestCase
 {
@@ -44,17 +45,25 @@ class AbstractIndexerTest extends AbstractUnitTestCase
      */
     protected $connection;
 
+    /**
+     * @var ObjectManagerInterface
+     */
+    protected $objectManager;
+
     public function setUp()
     {
         parent::setUp();
 
         $this->configuration = $this->getMockBuilder(ConfigurationContainerInterface::class)->getMock();
         $this->connection = $this->getMockBuilder(ConnectionInterface::class)->getMock();
+        $this->objectManager = $this->getMockBuilder(ObjectManagerInterface::class)->getMock();
+
 
         $this->subject = $this->getMockForAbstractClass(AbstractIndexer::class, [
             $this->connection,
             $this->configuration
         ]);
+        $this->inject($this->subject, 'objectManager', $this->objectManager);
         $this->subject->injectLogger($this->getMockedLogger());
         $this->subject->setIdentifier('testTable');
         $this->subject->expects($this->any())
@@ -72,6 +81,11 @@ class AbstractIndexerTest extends AbstractUnitTestCase
         $expectedRecord['new_test_field'] = 'test';
         $expectedRecord['new_test_field2'] = 'test' . PHP_EOL . 'test';
         $expectedRecord['search_abstract'] = '';
+
+        $this->objectManager->expects($this->any())
+            ->method('get')
+            ->with(CopyToProcessor::class)
+            ->willReturn(new CopyToProcessor());
 
         $this->configuration->expects($this->exactly(2))
             ->method('get')


### PR DESCRIPTION
This way injects will be resolved inside of processors, enabling
developers to inject dependencies.

We use inject instead of constructor as indexers mostly will change the
constructor and should not need to add the objectmanager.

Resolves: #117