### PR TITLE
!!!|FEATURE: 120 Pass facet configuration to search service

### DIFF
--- a/Classes/Connection/Elasticsearch/Facet.php
+++ b/Classes/Connection/Elasticsearch/Facet.php
@@ -45,25 +45,26 @@ class Facet implements FacetInterface
      */
     protected $options = [];
 
-    public function __construct($name, array $aggregation, ConfigurationContainerInterface $configuration)
+    public function __construct(string $name, array $aggregation, ConfigurationContainerInterface $configuration)
     {
         $this->name = $name;
         $this->buckets = $aggregation['buckets'];
-        $this->field = $configuration->getIfExists('searching.facets.' . $this->name . '.field') ?: '';
+
+        $config = $configuration->getIfExists('searching.facets.' . $this->name) ?: [];
+        foreach ($config as $configEntry) {
+            if (isset($configEntry['field'])) {
+                $this->field = $configEntry['field'];
+                break;
+            }
+        }
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName() : string
     {
         return $this->name;
     }
 
-    /**
-     * @return string
-     */
-    public function getField()
+    public function getField() : string
     {
         return $this->field;
     }
@@ -73,7 +74,7 @@ class Facet implements FacetInterface
      *
      * @return array<FacetOptionInterface>
      */
-    public function getOptions()
+    public function getOptions() : array
     {
         $this->initOptions();
 

--- a/Classes/Connection/FacetRequestInterface.php
+++ b/Classes/Connection/FacetRequestInterface.php
@@ -28,15 +28,11 @@ interface FacetRequestInterface
     /**
      * The identifier of the facet, used as key in arrays and to get the facet
      * from search request, etc.
-     *
-     * @return string
      */
-    public function getIdentifier();
+    public function getIdentifier() : string;
 
     /**
-     * The field to use for facet building.
-     *
-     * @return string
+     * The config to use for facet building.
      */
-    public function getField();
+    public function getConfig() : array;
 }

--- a/Classes/Domain/Model/FacetRequest.php
+++ b/Classes/Domain/Model/FacetRequest.php
@@ -30,37 +30,27 @@ class FacetRequest implements FacetRequestInterface
     protected $identifier = '';
 
     /**
-     * @var string
+     * @var array
      */
-    protected $field = '';
+    protected $config = [];
 
     /**
-     * TODO: Add validation / exception?
      * As the facets come from configuration this might be a good idea to help
      * integrators find issues.
-     *
-     * @param string $identifier
-     * @param string $field
      */
-    public function __construct($identifier, $field)
+    public function __construct(string $identifier, array $config)
     {
         $this->identifier = $identifier;
-        $this->field = $field;
+        $this->config = $config;
     }
 
-    /**
-     * @return string
-     */
-    public function getIdentifier()
+    public function getIdentifier() : string
     {
         return $this->identifier;
     }
 
-    /**
-     * @return string
-     */
-    public function getField()
+    public function getConfig() : array
     {
-        return $this->field;
+        return $this->config;
     }
 }

--- a/Classes/Domain/Search/QueryFactory.php
+++ b/Classes/Domain/Search/QueryFactory.php
@@ -239,11 +239,7 @@ class QueryFactory
         foreach ($searchRequest->getFacets() as $facet) {
             $query = ArrayUtility::arrayMergeRecursiveOverrule($query, [
                 'aggs' => [
-                    $facet->getIdentifier() => [
-                        'terms' => [
-                            'field' => $facet->getField(),
-                        ],
-                    ],
+                    $facet->getIdentifier() => $facet->getConfig(),
                 ],
             ]);
         }

--- a/Classes/Domain/Search/SearchService.php
+++ b/Classes/Domain/Search/SearchService.php
@@ -103,15 +103,10 @@ class SearchService
         }
 
         foreach ($facetsConfig as $identifier => $facetConfig) {
-            if (!isset($facetConfig['field']) || trim($facetConfig['field']) === '') {
-                // TODO: Finish throw
-                throw new \Exception('message', 1499171142);
-            }
-
             $searchRequest->addFacet($this->objectManager->get(
                 FacetRequest::class,
                 $identifier,
-                $facetConfig['field']
+                $facetConfig
             ));
         }
     }

--- a/Documentation/source/changelog.rst
+++ b/Documentation/source/changelog.rst
@@ -1,0 +1,8 @@
+Changelog
+=========
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   changelog/*

--- a/Documentation/source/changelog/20180406-120-facet-configuration.rst
+++ b/Documentation/source/changelog/20180406-120-facet-configuration.rst
@@ -1,0 +1,40 @@
+Breacking Change 120 "Pass facets configuration to elasticsearch"
+=================================================================
+
+In order to allow arbitrary facet configuration, we do not process the facet configuration anymore.
+Instead integrators are able to configure facets for search service "as is". We just pipe the
+configuration through.
+
+Therefore the following, which worked before, does not work anymore:
+
+.. code-block:: typoscript
+   :linenos:
+   :emphasize-lines: 4
+
+    plugin.tx_searchcore.settings.search {
+        facets {
+            category {
+                field = categories
+            }
+        }
+    }
+
+Instead you have to provide the full configuration yourself:
+
+.. code-block:: typoscript
+   :linenos:
+   :emphasize-lines: 4,6
+
+    plugin.tx_searchcore.settings.search {
+        facets {
+            category {
+                terms {
+                    field = categories
+                }
+            }
+        }
+    }
+
+You need to add line 4 and 6, the additional level ``terms`` for elasticsearch.
+
+See :issue:`120`.

--- a/Documentation/source/index.rst
+++ b/Documentation/source/index.rst
@@ -15,3 +15,4 @@ Table of Contents
    connections
    indexer
    development
+   changelog

--- a/Tests/Functional/Connection/Elasticsearch/FacetTest.php
+++ b/Tests/Functional/Connection/Elasticsearch/FacetTest.php
@@ -25,8 +25,13 @@ use Codappix\SearchCore\Domain\Model\SearchRequest;
 use Codappix\SearchCore\Domain\Search\SearchService;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 
-class FilterTest extends AbstractFunctionalTestCase
+class FacetTest extends AbstractFunctionalTestCase
 {
+    protected function getTypoScriptFilesForFrontendRootPage()
+    {
+        return array_merge(parent::getTypoScriptFilesForFrontendRootPage(), ['EXT:search_core/Tests/Functional/Fixtures/Searching/Facet.ts']);
+    }
+
     protected function getDataSets()
     {
         return array_merge(
@@ -38,7 +43,7 @@ class FilterTest extends AbstractFunctionalTestCase
     /**
      * @test
      */
-    public function itsPossibleToFilterResultsByASingleField()
+    public function itsPossibleToFetchFacetsForField()
     {
         \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class)
             ->get(IndexerFactory::class)
@@ -48,14 +53,23 @@ class FilterTest extends AbstractFunctionalTestCase
 
         $searchService = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class)
             ->get(SearchService::class);
-        $searchRequest = new SearchRequest('Search Word');
 
+        $searchRequest = new SearchRequest();
         $result = $searchService->search($searchRequest);
-        $this->assertSame(2, count($result), 'Did not receive both indexed elements without filter.');
 
-        $searchRequest->setFilter(['CType' => 'HTML']);
-        $result = $searchService->search($searchRequest);
-        $this->assertSame(5, $result->getResults()[0]['uid'], 'Did not get the expected result entry.');
-        $this->assertSame(1, count($result), 'Did not receive the single filtered element.');
+        $this->assertSame(1, count($result->getFacets()), 'Did not receive the single defined facet.');
+
+        $facet = current($result->getFacets());
+        $this->assertSame('contentTypes', $facet->getName(), 'Name of facet was not as expected.');
+        $this->assertSame('CType', $facet->getField(), 'Field of facet was not expected.');
+
+        $options = $facet->getOptions();
+        $this->assertSame(2, count($options), 'Did not receive the expected number of possible options for facet.');
+        $option = $options['HTML'];
+        $this->assertSame('HTML', $option->getName(), 'Option did not have expected Name.');
+        $this->assertSame(1, $option->getCount(), 'Option did not have expected count.');
+        $option = $options['Header'];
+        $this->assertSame('Header', $option->getName(), 'Option did not have expected Name.');
+        $this->assertSame(1, $option->getCount(), 'Option did not have expected count.');
     }
 }

--- a/Tests/Functional/Fixtures/BasicSetup.ts
+++ b/Tests/Functional/Fixtures/BasicSetup.ts
@@ -37,12 +37,6 @@ plugin {
             }
 
             searching {
-                facets {
-                    contentTypes {
-                        field = CType
-                    }
-                }
-
                 fields {
                     query = _all
                 }

--- a/Tests/Functional/Fixtures/Searching/Facet.ts
+++ b/Tests/Functional/Fixtures/Searching/Facet.ts
@@ -1,0 +1,17 @@
+plugin {
+    tx_searchcore {
+        settings {
+            searching {
+                facets {
+                    contentTypes {
+                        terms {
+                            field = CType
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+module.tx_searchcore < plugin.tx_searchcore

--- a/Tests/Unit/Domain/Search/QueryFactoryTest.php
+++ b/Tests/Unit/Domain/Search/QueryFactoryTest.php
@@ -118,8 +118,8 @@ class QueryFactoryTest extends AbstractUnitTestCase
     {
         $this->configureConfigurationMockWithDefault();
         $searchRequest = new SearchRequest('SearchWord');
-        $searchRequest->addFacet(new FacetRequest('Identifier', 'FieldName'));
-        $searchRequest->addFacet(new FacetRequest('Identifier 2', 'FieldName 2'));
+        $searchRequest->addFacet(new FacetRequest('Identifier', ['terms' => ['field' => 'FieldName']]));
+        $searchRequest->addFacet(new FacetRequest('Identifier 2', ['terms' => ['field' => 'FieldName 2']]));
 
         $query = $this->subject->create($searchRequest);
         $this->assertSame(


### PR DESCRIPTION
Do not limit integrator in possibilities to configure.

Therefore previously configure facets for a field need to be adjusted to
contain full configuration for elasticsearch. See changelog.

Resolves: #120