### PR TITLE
FEATURE: Support display name for facet option

### DIFF
--- a/Classes/Connection/Elasticsearch/FacetOption.php
+++ b/Classes/Connection/Elasticsearch/FacetOption.php
@@ -30,6 +30,11 @@ class FacetOption implements FacetOptionInterface
     protected $name = '';
 
     /**
+     * @var string
+     */
+    protected $displayName = '';
+
+    /**
      * @var int
      */
     protected $count = 0;
@@ -40,21 +45,21 @@ class FacetOption implements FacetOptionInterface
     public function __construct(array $bucket)
     {
         $this->name = $bucket['key'];
+        $this->displayName = isset($bucket['key_as_string']) ? $bucket['key_as_string'] : $this->getName();
         $this->count = $bucket['doc_count'];
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName() : string
     {
         return $this->name;
     }
 
-    /**
-     * @return int
-     */
-    public function getCount()
+    public function getDisplayName() : string
+    {
+        return $this->displayName;
+    }
+
+    public function getCount() : int
     {
         return $this->count;
     }

--- a/Classes/Connection/FacetOptionInterface.php
+++ b/Classes/Connection/FacetOptionInterface.php
@@ -28,15 +28,17 @@ interface FacetOptionInterface
     /**
      * Returns the name of this option. Equivalent
      * to value used for filtering.
-     *
-     * @return string
      */
-    public function getName();
+    public function getName() : string;
+
+    /**
+     * If a pre-rendered name is provided, this will be returned.
+     * Otherwise it's the same as getName().
+     */
+    public function getDisplayName() : string;
 
     /**
      * Returns the number of found results for this option.
-     *
-     * @return int
      */
-    public function getCount();
+    public function getCount() : int;
 }

--- a/Tests/Unit/Connection/Elasticsearch/FacetOptionTest.php
+++ b/Tests/Unit/Connection/Elasticsearch/FacetOptionTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace Codappix\SearchCore\Tests\Unit\Connection\Elasticsearch;
+
+/*
+ * Copyright (C) 2018  Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use Codappix\SearchCore\Connection\Elasticsearch\FacetOption;
+use Codappix\SearchCore\Tests\Unit\AbstractUnitTestCase;
+
+class FacetOptionTest extends AbstractUnitTestCase
+{
+    /**
+     * @test
+     */
+    public function displayNameIsReturnedAsExpected()
+    {
+        $bucket = [
+            'key' => 'Name',
+            'key_as_string' => 'DisplayName',
+            'doc_count' => 10,
+        ];
+        $subject = new FacetOption($bucket);
+
+        $this->assertSame(
+            $bucket['key_as_string'],
+            $subject->getDisplayName(),
+            'Display name was not returned as expected.'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function displayNameIsReturnedAsExpectedIfNotProvided()
+    {
+        $bucket = [
+            'key' => 'Name',
+            'doc_count' => 10,
+        ];
+        $subject = new FacetOption($bucket);
+
+        $this->assertSame(
+            $bucket['key'],
+            $subject->getDisplayName(),
+            'Display name was not returned as expected.'
+        );
+    }
+}


### PR DESCRIPTION
As some search services, like elasticsearch, allow generation of a
string that should be displayed in frontend, we provide a new getter for
that.
The old existing name can be a fallback in custom implementations.