### PR TITLE
FEATURE: Index page if cache was cleared

### DIFF
--- a/Classes/Hook/DataHandler.php
+++ b/Classes/Hook/DataHandler.php
@@ -99,6 +99,24 @@ class DataHandler implements Singleton
         }
     }
 
+    public function clearCachePostProc(array $parameters, CoreDataHandler $dataHandler)
+    {
+        $pageUid = 0;
+
+        // If editor uses "small page blizzard"
+        if (isset($parameters['cacheCmd']) && is_numeric($parameters['cacheCmd'])) {
+            $pageUid = $parameters['cacheCmd'];
+        }
+        // If records were changed
+        if (isset($parameters['uid_page']) && is_numeric($parameters['uid_page'])) {
+            $pageUid = $parameters['uid_page'];
+        }
+
+        if ($pageUid > 0) {
+            $this->processRecord('pages', (int) $pageUid);
+        }
+    }
+
     protected function processRecord(string $table, int $uid) : bool
     {
         if (! $this->shouldProcessHookForTable($table)) {

--- a/Documentation/source/changelog.rst
+++ b/Documentation/source/changelog.rst
@@ -5,5 +5,6 @@ Changelog
    :maxdepth: 1
    :glob:
 
+   changelog/20180408-131-respect-page-cache-clear
    changelog/20180408-introduce-php70-type-hints
    changelog/20180406-120-facet-configuration

--- a/Documentation/source/changelog/20180408-131-respect-page-cache-clear.rst
+++ b/Documentation/source/changelog/20180408-131-respect-page-cache-clear.rst
@@ -1,0 +1,14 @@
+Feature 131 "Pages do not get indexed if content has changed"
+=============================================================
+
+Previously we only used DataHandler hooks triggered when processing records. This way we did not
+index a page when content has changed.
+
+We now also use cache clear hooks of DataHandler to index pages whenever their cache get cleared.
+This way we also index a page if an integrator configured to clear further pages if content was
+changed.
+
+Still there are limitations. We do not get informed for pages which got cleared due to attached
+caches via TypoScript.
+
+See :issue:`131`.

--- a/Tests/Functional/Hooks/DataHandler/NonAllowedTablesTest.php
+++ b/Tests/Functional/Hooks/DataHandler/NonAllowedTablesTest.php
@@ -47,7 +47,11 @@ class NonAllowedTablesTest extends AbstractDataHandlerTest
      */
     public function deletionWillNotBeTriggeredForSysCategories()
     {
-        $this->subject->expects($this->exactly(0))->method('delete');
+        $this->subject->expects($this->exactly(1))
+            ->method('update')
+            ->with('pages', $this->callback(function (array $record) {
+                return isset($record['uid']) && $record['uid'] === 1;
+            }));
 
         $tce = GeneralUtility::makeInstance(Typo3DataHandler::class);
         $tce->stripslashes_values = 0;
@@ -66,7 +70,11 @@ class NonAllowedTablesTest extends AbstractDataHandlerTest
      */
     public function updateWillNotBeTriggeredForExistingSysCategory()
     {
-        $this->subject->expects($this->exactly(0))->method('update');
+        $this->subject->expects($this->exactly(1))
+            ->method('update')
+            ->with('pages', $this->callback(function (array $record) {
+                return isset($record['uid']) && $record['uid'] === 1;
+            }));
 
         $tce = GeneralUtility::makeInstance(Typo3DataHandler::class);
         $tce->stripslashes_values = 0;
@@ -85,7 +93,11 @@ class NonAllowedTablesTest extends AbstractDataHandlerTest
      */
     public function updateWillNotBeTriggeredForNewSysCategoy()
     {
-        $this->subject->expects($this->exactly(0))->method('update');
+        $this->subject->expects($this->exactly(1))
+            ->method('update')
+            ->with('pages', $this->callback(function (array $record) {
+                return isset($record['uid']) && $record['uid'] === 1;
+            }));
 
         $tce = GeneralUtility::makeInstance(Typo3DataHandler::class);
         $tce->stripslashes_values = 0;

--- a/Tests/Functional/Hooks/DataHandler/ProcessesAllowedTablesTest.php
+++ b/Tests/Functional/Hooks/DataHandler/ProcessesAllowedTablesTest.php
@@ -50,6 +50,11 @@ class ProcessesAllowedTablesTest extends AbstractDataHandlerTest
         $this->subject->expects($this->exactly(1))
             ->method('delete')
             ->with($this->equalTo('tt_content'), $this->equalTo('1'));
+        $this->subject->expects($this->exactly(1))
+            ->method('update')
+            ->with('pages', $this->callback(function (array $record) {
+                return isset($record['uid']) && $record['uid'] === 1;
+            }));
 
         $tce = GeneralUtility::makeInstance(Typo3DataHandler::class);
         $tce->stripslashes_values = 0;
@@ -68,15 +73,23 @@ class ProcessesAllowedTablesTest extends AbstractDataHandlerTest
      */
     public function updateWillBeTriggeredForExistingTtContent()
     {
-        $this->subject->expects($this->exactly(1))->method('update')
-            ->with(
-                $this->equalTo('tt_content'),
-                $this->callback(function ($record) {
-                    return isset($record['uid']) && $record['uid'] === 1
-                        && isset($record['pid']) && $record['pid'] === 1
-                        && isset($record['colPos']) && $record['colPos'] === 1
-                        ;
-                })
+        $this->subject->expects($this->exactly(2))->method('update')
+            ->withConsecutive(
+                [
+                    $this->equalTo('tt_content'),
+                    $this->callback(function ($record) {
+                        return isset($record['uid']) && $record['uid'] === 1
+                            && isset($record['pid']) && $record['pid'] === 1
+                            && isset($record['colPos']) && $record['colPos'] === 1
+                            ;
+                    })
+                ],
+                [
+                    $this->equalTo('pages'),
+                    $this->callback(function ($record) {
+                        return isset($record['uid']) && $record['uid'] === 1;
+                    })
+                ]
             );
 
         $tce = GeneralUtility::makeInstance(Typo3DataHandler::class);
@@ -96,15 +109,23 @@ class ProcessesAllowedTablesTest extends AbstractDataHandlerTest
      */
     public function updateWillBeTriggeredForNewTtContent()
     {
-        $this->subject->expects($this->exactly(1))->method('update')
-            ->with(
-                $this->equalTo('tt_content'),
-                $this->callback(function ($record) {
-                    return isset($record['uid']) && $record['uid'] === 2
-                        && isset($record['pid']) && $record['pid'] === 1
-                        && isset($record['header']) && $record['header'] === 'a new record'
-                        ;
-                })
+        $this->subject->expects($this->exactly(2))->method('update')
+            ->withConsecutive(
+                [
+                    $this->equalTo('tt_content'),
+                    $this->callback(function ($record) {
+                        return isset($record['uid']) && $record['uid'] === 2
+                            && isset($record['pid']) && $record['pid'] === 1
+                            && isset($record['header']) && $record['header'] === 'a new record'
+                            ;
+                    })
+                ],
+                [
+                    $this->equalTo('pages'),
+                    $this->callback(function ($record) {
+                        return isset($record['uid']) && $record['uid'] === 1;
+                    })
+                ]
             );
 
         $tce = GeneralUtility::makeInstance(Typo3DataHandler::class);

--- a/Tests/Unit/Hook/DataHandlerTest.php
+++ b/Tests/Unit/Hook/DataHandlerTest.php
@@ -1,0 +1,94 @@
+<?php
+namespace Codappix\SearchCore\Tests\Unit\Hook;
+
+/*
+ * Copyright (C) 2018  Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use Codappix\SearchCore\Domain\Service\DataHandler as OwnDataHandler;
+use Codappix\SearchCore\Hook\DataHandler;
+use Codappix\SearchCore\Tests\Unit\AbstractUnitTestCase;
+use TYPO3\CMS\Core\DataHandling\DataHandler as CoreDataHandler;
+
+class DataHandlerToProcessorTest extends AbstractUnitTestCase
+{
+    /**
+     * @test
+     * @dataProvider getPossibleCallCombinations
+     */
+    public function fieldsAreCopiedAsConfigured(array $parameters, bool $expectCall)
+    {
+        $coreDataHandlerMock = $this->getMockBuilder(CoreDataHandler::class)->getMock();
+        $ownDataHandlerMock = $this->getMockBuilder(OwnDataHandler::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $subject = $this->getMockBuilder(DataHandler::class)
+            ->setConstructorArgs([$ownDataHandlerMock])
+            ->setMethods(['getRecord'])
+            ->getMock();
+
+        $ownDataHandlerMock->expects($this->any())
+            ->method('supportsTable')
+            ->willReturn(true);
+
+        if ($expectCall) {
+            $subject->expects($this->once())
+                ->method('getRecord')
+                ->with('pages', 10)
+                ->willReturn(['uid' => 10]);
+            $ownDataHandlerMock->expects($this->once())
+                ->method('update')
+                ->with('pages', ['uid' => 10]);
+        } else {
+            $subject->expects($this->never())
+                ->method('getRecord');
+            $ownDataHandlerMock->expects($this->never())
+                ->method('update');
+        }
+
+        $subject->clearCachePostProc($parameters, $coreDataHandlerMock);
+    }
+
+    public function getPossibleCallCombinations() : array
+    {
+        return [
+            'Editor triggered cache clear of page manual' => [
+                'parameters' => [
+                    'cacheCmd' => '10',
+                ],
+                'expectCall' => true,
+            ],
+            'Editor changed records on a page' => [
+                'parameters' => [
+                    'uid_page' =>10,
+                ],
+                'expectCall' => true,
+            ],
+            'Something unexpected' => [
+                'parameters' => [],
+                'expectCall' => false,
+            ],
+            'Something unexpected' => [
+                'parameters' => [
+                    'cacheCmd' => 'something like a tag?!',
+                ],
+                'expectCall' => false,
+            ],
+        ];
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -15,6 +15,9 @@ call_user_func(
                         ],
                     ],
                     't3lib/class.t3lib_tcemain.php' => [
+                        'clearCachePostProc' => [
+                            $extensionKey => \Codappix\SearchCore\Hook\DataHandler::class . '->clearCachePostProc',
+                        ],
                         'processCmdmapClass' => [
                             $extensionKey => \Codappix\SearchCore\Hook\DataHandler::class,
                         ],


### PR DESCRIPTION
We use the cache clear hook to index pages whenever the cache was
cleared.
This makes it possible to cover some cases like changing content on a
page. But also if an integrator configures to clear additional pages.

This is limited as we can not handle cache tags at the moment.

Resolves: #131