### PR TITLE
FEATURE: Make content fields configurable

### DIFF
--- a/Classes/Domain/Index/TcaIndexer/PagesIndexer.php
+++ b/Classes/Domain/Index/TcaIndexer/PagesIndexer.php
@@ -24,6 +24,7 @@ use Codappix\SearchCore\Configuration\ConfigurationContainerInterface;
 use Codappix\SearchCore\Connection\ConnectionInterface;
 use Codappix\SearchCore\Domain\Index\TcaIndexer;
 use Codappix\SearchCore\Domain\Index\TcaIndexer\TcaTableService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Specific indexer for Pages, will basically add content of page.
@@ -103,7 +104,7 @@ class PagesIndexer extends TcaIndexer
                 $images,
                 $this->getContentElementImages($contentElement['uid'])
             );
-            $content[] = $contentElement['bodytext'];
+            $content[] = $this->getContentFromContentElement($contentElement);
         }
 
         return [
@@ -135,5 +136,23 @@ class PagesIndexer extends TcaIndexer
         }
 
         return $imageRelationUids;
+    }
+
+    protected function getContentFromContentElement(array $contentElement) : string
+    {
+        $content = '';
+
+        $fieldsWithContent = GeneralUtility::trimExplode(
+            ',',
+            $this->configuration->get('indexing.' . $this->identifier . '.contentFields'),
+            true
+        );
+        foreach ($fieldsWithContent as $fieldWithContent) {
+            if (isset($contentElement[$fieldWithContent]) && trim($contentElement[$fieldWithContent])) {
+                $content .= trim($contentElement[$fieldWithContent]) . ' ';
+            }
+        }
+
+        return trim($content);
     }
 }

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -10,12 +10,13 @@ plugin {
 
             indexing {
                 tt_content {
-                    additionalWhereClause = tt_content.CType NOT IN ('gridelements_pi1', 'list', 'div', 'menu', 'shortcut', 'search', 'login') AND tt_content.bodytext != ''
+                    additionalWhereClause = tt_content.CType NOT IN ('gridelements_pi1', 'list', 'div', 'menu', 'shortcut', 'search', 'login') AND (tt_content.bodytext != '' OR tt_content.header != '')
                 }
 
                 pages {
                     additionalWhereClause = pages.doktype NOT IN (3, 199, 6, 254, 255)
                     abstractFields = abstract, description, bodytext
+                    contentFields = header, bodytext
                 }
             }
         }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -19,6 +19,7 @@ plugin {
                     indexer = Codappix\SearchCore\Domain\Index\TcaIndexer\PagesIndexer
                     additionalWhereClause = {$plugin.tx_searchcore.settings.indexing.pages.additionalWhereClause}
                     abstractFields = {$plugin.tx_searchcore.settings.indexing.pages.abstractFields}
+                    contentFields = {$plugin.tx_searchcore.settings.indexing.pages.abstractFields}
                 }
             }
 

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -19,7 +19,7 @@ plugin {
                     indexer = Codappix\SearchCore\Domain\Index\TcaIndexer\PagesIndexer
                     additionalWhereClause = {$plugin.tx_searchcore.settings.indexing.pages.additionalWhereClause}
                     abstractFields = {$plugin.tx_searchcore.settings.indexing.pages.abstractFields}
-                    contentFields = {$plugin.tx_searchcore.settings.indexing.pages.abstractFields}
+                    contentFields = {$plugin.tx_searchcore.settings.indexing.pages.contentFields}
                 }
             }
 

--- a/Documentation/source/changelog.rst
+++ b/Documentation/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
    :maxdepth: 1
    :glob:
 
+   changelog/20180415-134-make-conent-fields-configurable
    changelog/20180409-25-provide-sys-language-uid
    changelog/20180408-131-respect-page-cache-clear
    changelog/20180408-introduce-php70-type-hints

--- a/Documentation/source/changelog/20180415-134-make-conent-fields-configurable.rst
+++ b/Documentation/source/changelog/20180415-134-make-conent-fields-configurable.rst
@@ -1,0 +1,13 @@
+FEATURE 134 "Enable indexing of tt_content records of CType Header"
+===================================================================
+
+Before, only ``bodytext`` was used to generate content while indexing pages.
+
+As there are content elements like ``header`` where this field is empty, but content is still
+available, it's now possible to configure the fields.
+This makes it also possible to configure further custom content elements with new columns.
+
+A new TypoScript option is now available, and ``header`` is added by default, see
+:ref:`contentFields`.
+
+See :issue:`134`.

--- a/Documentation/source/configuration/indexing.rst
+++ b/Documentation/source/configuration/indexing.rst
@@ -86,6 +86,23 @@ Default::
 
     abstract, description, bodytext
 
+.. _contentFields:
+
+contentFields
+-------------
+
+Used by: :ref:`PagesIndexer`.
+
+Define which fields should be used to provide the auto generated field "content".
+
+Example::
+
+    plugin.tx_searchcore.settings.indexing.pages.contentFields := addToList(table_caption)
+
+Default::
+
+    header, bodytext
+
 .. _mapping:
 
 mapping

--- a/Tests/Functional/Fixtures/BasicSetup.ts
+++ b/Tests/Functional/Fixtures/BasicSetup.ts
@@ -14,7 +14,7 @@ plugin {
 
                     additionalWhereClause (
                         tt_content.CType NOT IN ('gridelements_pi1', 'list', 'div', 'menu', 'shortcut', 'search', 'login')
-                        AND tt_content.bodytext != ''
+                        AND (tt_content.bodytext != '' OR tt_content.header != '')
                     )
 
                     mapping {
@@ -27,6 +27,7 @@ plugin {
                 pages {
                     indexer = Codappix\SearchCore\Domain\Index\TcaIndexer\PagesIndexer
                     abstractFields = abstract, description, bodytext
+                    contentFields = header, bodytext
 
                     mapping {
                         CType {

--- a/Tests/Functional/Indexing/PagesIndexerTest.php
+++ b/Tests/Functional/Indexing/PagesIndexerTest.php
@@ -50,7 +50,9 @@ class PagesIndexerTest extends AbstractFunctionalTestCase
                 $this->callback(function ($documents) {
                     return count($documents) === 1
                         && isset($documents[0]['content']) && $documents[0]['content'] ===
-                        'this is the content of header content element that should get indexed Some text in paragraph'
+                        'indexed content element' .
+                        ' this is the content of header content element that should get indexed' .
+                        ' Indexed without html tags Some text in paragraph'
                         && isset($documents[0]['search_abstract']) && $documents[0]['search_abstract'] ===
                         'Used as abstract as no abstract is defined.'
                         ;


### PR DESCRIPTION
Allows integrators to configure which fields should be used to produce
field "content" for indexed pages.

Before only "bodytext" was used. This is now configurable and "header"
was added to defaults.

Resolves: #134