### PR TITLE
BUGFIX: Allow multiple instances with different configurations

### DIFF
--- a/Classes/Configuration/ConfigurationContainerInterface.php
+++ b/Classes/Configuration/ConfigurationContainerInterface.php
@@ -20,13 +20,11 @@ namespace Codappix\SearchCore\Configuration;
  * 02110-1301, USA.
  */
 
-use TYPO3\CMS\Core\SingletonInterface as Singleton;
-
 /**
  * Container of all configurations for extension.
- * Always inject this to have a single place for configuration and parsing only once.
+ * Always inject this to have a single place for configuration.
  */
-interface ConfigurationContainerInterface extends Singleton
+interface ConfigurationContainerInterface
 {
     /**
      * Returns the option defined by section and key.


### PR DESCRIPTION
In order to use the plugin with different configurations on same site,
we can not use ConfigurationContainerInterface as a Singleton.
This would prevents us from using different configuration setups.