### PR TITLE
TASK: Prevent issue When hook is called with non uid

### DIFF
--- a/Classes/Hook/DataHandler.php
+++ b/Classes/Hook/DataHandler.php
@@ -72,7 +72,7 @@ class DataHandler implements Singleton
     /**
      * Called by CoreDataHandler on deletion of records.
      */
-    public function processCmdmap_deleteAction(string $table, int $uid) : bool
+    public function processCmdmap_deleteAction(string $table, string $uid) : bool
     {
         if (! $this->shouldProcessHookForTable($table)) {
             $this->logger->debug('Delete not processed.', [$table, $uid]);
@@ -93,6 +93,10 @@ class DataHandler implements Singleton
                 $uid = $fieldData['uid'];
             } elseif (isset($dataHandler->substNEWwithIDs[$uid])) {
                 $uid = $dataHandler->substNEWwithIDs[$uid];
+            }
+
+            if (!is_numeric($uid) || $uid <= 0) {
+                continue;
             }
 
             $this->processRecord($table, $uid);

--- a/Tests/Unit/Hook/DataHandlerTest.php
+++ b/Tests/Unit/Hook/DataHandlerTest.php
@@ -113,7 +113,7 @@ class DataHandlerToProcessorTest extends AbstractUnitTestCase
     /**
      * @test
      */
-    public function indexingIsNotCalledForProcesIfDataIsInvalid()
+    public function indexingIsNotCalledForProcessIfDataIsInvalid()
     {
         $coreDataHandlerMock = $this->getMockBuilder(CoreDataHandler::class)->getMock();
         $coreDataHandlerMock->datamap = [

--- a/Tests/Unit/Hook/DataHandlerTest.php
+++ b/Tests/Unit/Hook/DataHandlerTest.php
@@ -91,4 +91,46 @@ class DataHandlerToProcessorTest extends AbstractUnitTestCase
             ],
         ];
     }
+
+    /**
+     * @test
+     */
+    public function indexingIsNotCalledForCacheClearIfDataIsInvalid()
+    {
+        $coreDataHandlerMock = $this->getMockBuilder(CoreDataHandler::class)->getMock();
+        $ownDataHandlerMock = $this->getMockBuilder(OwnDataHandler::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $subject = new DataHandler($ownDataHandlerMock);
+
+        $ownDataHandlerMock->expects($this->never())->method('update');
+
+        $subject->clearCachePostProc([
+            'cacheCmd' => 'NEW343',
+        ], $coreDataHandlerMock);
+    }
+    /**
+     * @test
+     */
+    public function indexingIsNotCalledForProcesIfDataIsInvalid()
+    {
+        $coreDataHandlerMock = $this->getMockBuilder(CoreDataHandler::class)->getMock();
+        $coreDataHandlerMock->datamap = [
+            'tt_content' => [
+                'NEW343' => [],
+            ],
+        ];
+        $coreDataHandlerMock->substNEWwithIDs = [];
+
+        $ownDataHandlerMock = $this->getMockBuilder(OwnDataHandler::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $subject = new DataHandler($ownDataHandlerMock);
+
+        $ownDataHandlerMock->expects($this->never())->method('update');
+
+        $subject->processDatamap_afterAllOperations($coreDataHandlerMock);
+    }
 }


### PR DESCRIPTION
If some issues occur outside of our extension, we might not get a valid
uid inside of our hooks. We will therefore add additional checks and
prevent any further execution.

Resolves: #112