### PR TITLE
FEATURE: Provide type of result item

### DIFF
--- a/Classes/Connection/Elasticsearch/SearchResult.php
+++ b/Classes/Connection/Elasticsearch/SearchResult.php
@@ -108,7 +108,7 @@ class SearchResult implements SearchResultInterface
         }
 
         foreach ($this->result->getResults() as $result) {
-            $this->results[] = new ResultItem($result->getData());
+            $this->results[] = new ResultItem($result->getData(), $result->getParam('_type'));
         }
     }
 

--- a/Classes/Connection/ResultItemInterface.php
+++ b/Classes/Connection/ResultItemInterface.php
@@ -33,4 +33,12 @@ interface ResultItemInterface extends \ArrayAccess
      * Used e.g. for dataprocessing.
      */
     public function getPlainData() : array;
+
+    /**
+     * Returns the type of the item.
+     *
+     * That should make it easier to differentiate if multiple
+     * types are returned for one query.
+     */
+    public function getType() : string;
 }

--- a/Classes/Domain/Model/ResultItem.php
+++ b/Classes/Domain/Model/ResultItem.php
@@ -29,9 +29,20 @@ class ResultItem implements ResultItemInterface
      */
     protected $data = [];
 
-    public function __construct(array $result)
+    /**
+     * @var string
+     */
+    protected $type = '';
+
+    public function __construct(array $result, string $type)
     {
         $this->data = $result;
+        $this->type = $type;
+    }
+
+    public function getType() : string
+    {
+        return $this->type;
     }
 
     public function getPlainData() : array

--- a/Classes/Domain/Model/SearchResult.php
+++ b/Classes/Domain/Model/SearchResult.php
@@ -76,7 +76,7 @@ class SearchResult implements SearchResultInterface
         }
 
         foreach ($this->resultItems as $item) {
-            $this->results[] = new ResultItem($item);
+            $this->results[] = new ResultItem($item['data'], $item['type']);
         }
     }
 

--- a/Classes/Domain/Search/SearchService.php
+++ b/Classes/Domain/Search/SearchService.php
@@ -146,10 +146,13 @@ class SearchService
             $newSearchResultItems = [];
             foreach ($this->configuration->get('searching.dataProcessing') as $configuration) {
                 foreach ($searchResult as $resultItem) {
-                    $newSearchResultItems[] = $this->dataProcessorService->executeDataProcessor(
-                        $configuration,
-                        $resultItem->getPlainData()
-                    );
+                    $newSearchResultItems[] = [
+                        'data' => $this->dataProcessorService->executeDataProcessor(
+                            $configuration,
+                            $resultItem->getPlainData()
+                        ),
+                        'type' => $resultItem->getType(),
+                    ];
                 }
             }
 

--- a/Tests/Unit/Domain/Model/ResultItemTest.php
+++ b/Tests/Unit/Domain/Model/ResultItemTest.php
@@ -36,7 +36,7 @@ class ResultItemTest extends AbstractUnitTestCase
         ];
         $expectedData = $originalData;
 
-        $subject = new ResultItem($originalData);
+        $subject = new ResultItem($originalData, 'testType');
         $this->assertSame(
             $expectedData,
             $subject->getPlainData(),
@@ -55,7 +55,7 @@ class ResultItemTest extends AbstractUnitTestCase
         ];
         $expectedData = $originalData;
 
-        $subject = new ResultItem($originalData);
+        $subject = new ResultItem($originalData, 'testType');
         $this->assertSame(
             $originalData['title'],
             $subject['title'],
@@ -73,7 +73,7 @@ class ResultItemTest extends AbstractUnitTestCase
             'title' => 'Some title',
         ];
 
-        $subject = new ResultItem($originalData);
+        $subject = new ResultItem($originalData, 'testType');
         $this->assertTrue(isset($subject['title']), 'Could not determine that title exists.');
         $this->assertFalse(isset($subject['title2']), 'Could not determine that title2 does not exists.');
     }
@@ -88,7 +88,7 @@ class ResultItemTest extends AbstractUnitTestCase
             'title' => 'Some title',
         ];
 
-        $subject = new ResultItem($originalData);
+        $subject = new ResultItem($originalData, 'testType');
         $this->expectException(\BadMethodCallException::class);
         $subject['title'] = 'New Title';
     }
@@ -103,8 +103,57 @@ class ResultItemTest extends AbstractUnitTestCase
             'title' => 'Some title',
         ];
 
-        $subject = new ResultItem($originalData);
+        $subject = new ResultItem($originalData, 'testType');
         $this->expectException(\BadMethodCallException::class);
         unset($subject['title']);
+    }
+
+    /**
+     * @test
+     */
+    public function typeCanBeRetrievedAfterConstruction()
+    {
+        $originalData = [
+            'uid' => 10,
+            'title' => 'Some title',
+        ];
+        $expectedData = $originalData;
+
+        $subject = new ResultItem($originalData, 'testType');
+        $this->assertSame(
+            'testType',
+            $subject->getType(),
+            'Could not retrieve type.'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function typeCanNotBeChanged()
+    {
+        $originalData = [
+            'uid' => 10,
+            'title' => 'Some title',
+        ];
+
+        $subject = new ResultItem($originalData, 'testType');
+        $this->expectException(\BadMethodCallException::class);
+        $subject['type'] = 'New Title';
+    }
+
+    /**
+     * @test
+     */
+    public function typeCanNotBeRemoved()
+    {
+        $originalData = [
+            'uid' => 10,
+            'title' => 'Some title',
+        ];
+
+        $subject = new ResultItem($originalData, 'testType');
+        $this->expectException(\BadMethodCallException::class);
+        unset($subject['type']);
     }
 }

--- a/Tests/Unit/Domain/Model/SearchResultTest.php
+++ b/Tests/Unit/Domain/Model/SearchResultTest.php
@@ -71,16 +71,25 @@ class SearchResultTest extends AbstractUnitTestCase
         $originalSearchResultMock = $this->getMockBuilder(SearchResultInterface::class)->getMock();
         $data = [
             [
-                'uid' => 10,
-                'title' => 'Some Title',
+                'data' => [
+                    'uid' => 10,
+                    'title' => 'Some Title',
+                ],
+                'type' => 'testType1',
             ],
             [
-                'uid' => 11,
-                'title' => 'Some Title 2',
+                'data' => [
+                    'uid' => 11,
+                    'title' => 'Some Title 2',
+                ],
+                'type' => 'testType2',
             ],
             [
-                'uid' => 12,
-                'title' => 'Some Title 3',
+                'data' => [
+                    'uid' => 12,
+                    'title' => 'Some Title 3',
+                ],
+                'type' => 'testType2',
             ],
         ];
 
@@ -89,9 +98,12 @@ class SearchResultTest extends AbstractUnitTestCase
 
         $this->assertCount(3, $resultItems);
 
-        $this->assertSame($data[0]['uid'], $resultItems[0]['uid']);
-        $this->assertSame($data[1]['uid'], $resultItems[1]['uid']);
-        $this->assertSame($data[2]['uid'], $resultItems[2]['uid']);
+        $this->assertSame($data[0]['data']['uid'], $resultItems[0]['uid']);
+        $this->assertSame($data[0]['type'], $resultItems[0]->getType());
+        $this->assertSame($data[1]['data']['uid'], $resultItems[1]['uid']);
+        $this->assertSame($data[1]['type'], $resultItems[1]->getType());
+        $this->assertSame($data[2]['data']['uid'], $resultItems[2]['uid']);
+        $this->assertSame($data[2]['type'], $resultItems[2]->getType());
 
         $this->assertInstanceOf(ResultItemInterface::class, $resultItems[0]);
         $this->assertInstanceOf(ResultItemInterface::class, $resultItems[1]);

--- a/Tests/Unit/Domain/Search/SearchServiceTest.php
+++ b/Tests/Unit/Domain/Search/SearchServiceTest.php
@@ -294,7 +294,14 @@ class SearchServiceTest extends AbstractUnitTestCase
             ));
 
         $searchResultMock = $this->getMockBuilder(SearchResultInterface::class)->getMock();
-        $searchResult = new SearchResult($searchResultMock, [['field 1' => 'value 1']]);
+        $searchResult = new SearchResult($searchResultMock, [
+            [
+                'data' => [
+                    'field 1' => 'value 1'
+                ],
+                'type' => 'testType',
+            ],
+        ]);
 
         $this->connection->expects($this->once())
             ->method('search')
@@ -311,7 +318,13 @@ class SearchServiceTest extends AbstractUnitTestCase
         $this->objectManager->expects($this->once())
             ->method('get')
             ->with(SearchResult::class, $searchResult, [
-                ['field 1' => 'value 1', 'field 2' => 'value 2']
+                [
+                    'data' => [
+                        'field 1' => 'value 1',
+                        'field 2' => 'value 2',
+                    ],
+                    'type' => 'testType',
+                ]
             ])
             ->willReturn($searchResultMock);
 


### PR DESCRIPTION
In order to make further usage easier, we provide the type for each
result item.

This makes it possible to call {f:render(section: resultItem.type)}.