### PR TITLE
FEATURE: Keep sys_language_uid while indexing

### DIFF
--- a/Classes/Domain/Index/TcaIndexer/RelationResolver.php
+++ b/Classes/Domain/Index/TcaIndexer/RelationResolver.php
@@ -37,7 +37,8 @@ class RelationResolver implements Singleton
     {
         foreach (array_keys($record) as $column) {
             // TODO: Define / configure fields to exclude?!
-            if ($column === 'pid') {
+            if (in_array($column, ['pid', $service->getLanguageUidColumn()])) {
+                $record[$column] = (int) $record[$column];
                 continue;
             }
 

--- a/Classes/Domain/Index/TcaIndexer/TcaTableService.php
+++ b/Classes/Domain/Index/TcaIndexer/TcaTableService.php
@@ -283,6 +283,15 @@ class TcaTableService implements TcaTableServiceInterface
         return $this->tca['columns'][$columnName]['config'];
     }
 
+    public function getLanguageUidColumn() : string
+    {
+        if (!isset($this->tca['ctrl']['languageField'])) {
+            return '';
+        }
+
+        return $this->tca['ctrl']['languageField'];
+    }
+
     /**
      * Checks whether the given record was blacklisted by root line.
      * This can be configured by typoscript as whole root lines can be black listed.

--- a/Classes/Domain/Index/TcaIndexer/TcaTableService76.php
+++ b/Classes/Domain/Index/TcaIndexer/TcaTableService76.php
@@ -290,6 +290,15 @@ class TcaTableService76 implements TcaTableServiceInterface
         return $this->tca['columns'][$columnName]['config'];
     }
 
+    public function getLanguageUidColumn() : string
+    {
+        if (!isset($this->tca['ctrl']['languageField'])) {
+            return '';
+        }
+
+        return $this->tca['ctrl']['languageField'];
+    }
+
     /**
      * Checks whether the given record was blacklisted by root line.
      * This can be configured by typoscript as whole root lines can be black listed.

--- a/Classes/Domain/Index/TcaIndexer/TcaTableServiceInterface.php
+++ b/Classes/Domain/Index/TcaIndexer/TcaTableServiceInterface.php
@@ -41,4 +41,6 @@ interface TcaTableServiceInterface
     public function getRecords(int $offset, int $limit) : array;
 
     public function getRecord(int $identifier) : array;
+
+    public function getLanguageUidColumn() : string;
 }

--- a/Documentation/source/changelog.rst
+++ b/Documentation/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
    :maxdepth: 1
    :glob:
 
+   changelog/20180410-148-keep-sys_language_uid
    changelog/20180315-134-make-conent-fields-configurable
    changelog/20180309-25-provide-sys-language-uid
    changelog/20180308-131-respect-page-cache-clear

--- a/Documentation/source/changelog/20180410-148-keep-sys_language_uid.rst
+++ b/Documentation/source/changelog/20180410-148-keep-sys_language_uid.rst
@@ -1,0 +1,10 @@
+Feature 148 "Cast sys_language_uid to int"
+==========================================
+
+While resolving relations the configured language uid field, fetched from TCA, will
+be casted to integer and returned immediately.
+
+This change prevents the bug mentioned in :issue:`148`, where `0` is casted to an
+empty string, which makes filtering hard.
+
+See :issue:`148`.

--- a/Tests/Functional/Indexing/TcaIndexerTest.php
+++ b/Tests/Functional/Indexing/TcaIndexerTest.php
@@ -103,11 +103,7 @@ class TcaIndexerTest extends AbstractFunctionalTestCase
             ->with(
                 $this->stringContains('tt_content'),
                 $this->callback(function ($documents) {
-                    if ($this->isLegacyVersion()) {
-                        return isset($documents[0]['sys_language_uid']) && $documents[0]['sys_language_uid'] === '2';
-                    } else {
-                        return isset($documents[0]['sys_language_uid']) && $documents[0]['sys_language_uid'] === 2;
-                    }
+                    return isset($documents[0]['sys_language_uid']) && $documents[0]['sys_language_uid'] === 2;
                 })
             );
 

--- a/Tests/Unit/Domain/Index/TcaIndexer/RelationResolverTest.php
+++ b/Tests/Unit/Domain/Index/TcaIndexer/RelationResolverTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace Codappix\SearchCore\Tests\Unit\Domain\Index\TcaIndexer;
+
+/*
+ * Copyright (C) 2018  Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use Codappix\SearchCore\Domain\Index\TcaIndexer\RelationResolver;
+use Codappix\SearchCore\Domain\Index\TcaIndexer\TcaTableServiceInterface;
+use Codappix\SearchCore\Tests\Unit\AbstractUnitTestCase;
+
+class RelationResolverTest extends AbstractUnitTestCase
+{
+    /**
+     * @var RelationResolver
+     */
+    protected $subject;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->subject = new RelationResolver();
+    }
+
+    /**
+     * @test
+     */
+    public function sysLanguageUidZeroIsKept()
+    {
+        $record = [
+            'sys_language_uid' => '0',
+        ];
+        $GLOBALS['TCA'] = [
+            'tt_content' => [
+                'columns' => [
+                    'sys_language_uid' => [
+                        'config' => [
+                            'default' => 0,
+                            'items' => [
+                                [
+                                    'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
+                                    '-1',
+                                    'flags-multiple',
+                                ],
+                            ],
+                            'renderType' => 'selectSingle',
+                            'special' => 'languages',
+                            'type' => 'select',
+                            'exclude' => '1',
+                            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.language',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $tableServiceMock = $this->getMockBuilder(TcaTableServiceInterface::class)->getMock();
+        $tableServiceMock->expects($this->any())
+            ->method('getTableName')
+            ->willReturn('tt_content');
+        $tableServiceMock->expects($this->any())
+            ->method('getLanguageUidColumn')
+            ->willReturn('sys_language_uid');
+        $tableServiceMock->expects($this->any())
+            ->method('getColumnConfig')
+            ->willReturn($GLOBALS['TCA']['tt_content']['columns']['sys_language_uid']['config']);
+
+        $this->subject->resolveRelationsForRecord($tableServiceMock, $record);
+
+        $this->assertSame(
+            [
+                'sys_language_uid' => 0,
+            ],
+            $record,
+            'sys_language_uid was not kept as zero.'
+        );
+    }
+}


### PR DESCRIPTION
Before this change, sys_language_uid was indexed as an empty string, due
to internal used TYPO3 API.
We now skip the configure field which defines language uid. This way you
can build filter based on current language.

Resolves #148