### PR TITLE
Feature: 163 allow zero as typoscript filter

### DIFF
--- a/Classes/Domain/Search/SearchService.php
+++ b/Classes/Domain/Search/SearchService.php
@@ -126,9 +126,7 @@ class SearchService
 
             ArrayUtility::mergeRecursiveWithOverrule(
                 $filter,
-                $this->configuration->get('searching.filter'),
-                true,
-                false
+                $this->configuration->get('searching.filter')
             );
 
             $searchRequest->setFilter($filter);

--- a/Documentation/source/changelog.rst
+++ b/Documentation/source/changelog.rst
@@ -13,3 +13,4 @@ Changelog
    changelog/20180308-131-respect-page-cache-clear
    changelog/20180308-introduce-php70-type-hints
    changelog/20180306-120-facet-configuration
+   changelog/20180926-163-allow-zero-as-typoscript-filter-value

--- a/Documentation/source/changelog/20180926-163-allow-zero-as-typoscript-filter-value.rst
+++ b/Documentation/source/changelog/20180926-163-allow-zero-as-typoscript-filter-value.rst
@@ -1,0 +1,10 @@
+Bugfix 163 "It's not possible to configure a filter via TS with value 0 - zero"
+===============================================================================
+
+Prior to the change it was not possible to define a filter while searching, via
+TypoScript, with the value `0`. `0` was filtered as empty value.
+
+Now the configured filter is no longer filtered, it's up to the integrator to provide
+proper configuration. Therefore `0` is now a valid and respected filter value.
+
+See :issue:`163`.


### PR DESCRIPTION
BUGFIX: Allow to define zero as valid filter value via TypoScript

The configured filter is no longer filtered, it's up to the integrator
to provide proper configuration. Therefore `0` is now a valid and
respected filter value.

Resolves: #163