### PR TITLE
TASK: Make multiple plugins with flexform settings possible

### DIFF
--- a/Classes/Configuration/ConfigurationContainer.php
+++ b/Classes/Configuration/ConfigurationContainer.php
@@ -45,8 +45,7 @@ class ConfigurationContainer implements ConfigurationContainerInterface
     {
         $this->settings = $configurationManager->getConfiguration(
             ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS,
-            'SearchCore',
-            'search'
+            'SearchCore'
         );
         if ($this->settings === null) {
             throw new NoConfigurationException('Could not fetch configuration.', 1484226842);

--- a/Documentation/source/changelog.rst
+++ b/Documentation/source/changelog.rst
@@ -14,3 +14,4 @@ Changelog
    changelog/20180308-introduce-php70-type-hints
    changelog/20180306-120-facet-configuration
    changelog/20180926-163-allow-zero-as-typoscript-filter-value
+   changelog/20181106-170-do-not-specify-the-pluginname-in-configurationcontainer

--- a/Documentation/source/changelog/20181106-170-do-not-specify-the-pluginname-in-configurationcontainer.rst
+++ b/Documentation/source/changelog/20181106-170-do-not-specify-the-pluginname-in-configurationcontainer.rst
@@ -1,0 +1,17 @@
+Feature 170 "Do not specify the pluginName in ConfigurationContainer"
+===============================================================================
+
+Prior to the change it was not possible to create a second plugin in a
+separate extension. The pluginName for the configuration was set to `search`.
+The problem was that the plugin specific settings could not be fetched.
+
+The configuration in `plugin.tx_exampleextension_pluginkey.settings {..}` and
+from flexform were not fetched.
+
+Now the pluginName is not set and the ConfigurationManager checks which plugin
+is used in the current context.
+
+It is now possible to create a second plugin. For example if you want to cache
+the output of your query or the filters you specified.
+
+See :issue:`170`.


### PR DESCRIPTION
Remove the specified pluginName in the
ConfigurationContainer so the correct settings for the
context can be fetched.

Resolves: #170