### PR TITLE
BUGFIX: Dont stop loop on empty array

### DIFF
--- a/Classes/Domain/Index/AbstractIndexer.php
+++ b/Classes/Domain/Index/AbstractIndexer.php
@@ -119,8 +119,10 @@ abstract class AbstractIndexer implements IndexerInterface
         $offset = 0;
         $limit = $this->getLimit();
 
-        while (($records = $this->getRecords($offset, $limit)) !== []) {
-            yield $records;
+        while (($records = $this->getRecords($offset, $limit)) !== null) {
+            if ($records !== []) {
+                yield $records;
+            }
             $offset += $limit;
         }
     }


### PR DESCRIPTION
If the fetched record batch gets emptied because of the rootline filter
the loop gets interrupted and lasting records may get skipped from
further processing